### PR TITLE
fix: add all kinds of delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,7 @@ All notable changes to the "Labelary" extension will be documented in this file.
 
 ## 1.0.4
 - Changed logo
+
+
+## 1.0.5
+- added possible string delimiters: "'`<>|{}[]()/\ and whitespaces, newlines, carriage returns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,5 @@ All notable changes to the "Labelary" extension will be documented in this file.
 
 
 ## 1.0.5
-- added possible string delimiters: "'`<>|{}[]()/\ and whitespaces, newlines, carriage returns
+- updated possible string delimiters to: "<>
+  - If you have a ZPL that contains any of these delimiters: don't use right-mouse-click; select string instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,5 +19,6 @@ All notable changes to the "Labelary" extension will be documented in this file.
 
 
 ## 1.0.5
-- updated possible string delimiters to: "<>
-  - If you have a ZPL that contains any of these delimiters: don't use right-mouse-click; select string instead.
+- added two separate buttons:
+  - View raw ZPL label -> for viewing raw ZPLs, delimited by "<>
+  - View Base64 label -> for base64 strings, delimited by "'`<>{}[]()|\/:;, and spaces, newlines, carriage returns

--- a/README.md
+++ b/README.md
@@ -10,14 +10,16 @@ View Labelary (ZPL), PDF and other base64-encoded formats in separate panel on r
 
 Use as follows:
 - Right-click somewhere in the Labelary or Base64 string in the Editor
-- Select `View label`
+- Select:
+  - `View raw ZPL label` -> for viewing raw ZPLs, delimited by "<>
+  - `View Base64 label` -> for Base64 strings, delimited by "'`<>{}[]()|\/:;, and spaces, newlines, carriage returns
 
-Alternatively, use `Ctrl` + `Shift` + `P` and search for `View label`.
+If delimited by something else: *select string*, right click and again select the option applicable.
 
 ## Supports
-- Labelary
+- Labelary (ZPL)
   - multiple labels in one ZPL string
-  - base64 string or ZPL string
+  - Base64 string or ZPL string
 
 - Base64
   - PDF

--- a/README.md
+++ b/README.md
@@ -36,6 +36,5 @@ Fork the [repo](https://github.com/roelkneepkens/labelary-extension/) and submit
 
 ## Acknowledgements
 - Incorporated the decoding part of [Jason Mejane](https://marketplace.visualstudio.com/publishers/JasonMejane)'s [Base64Viewer](https://marketplace.visualstudio.com/items?itemName=JasonMejane.base64viewer) (v1.2.1)
-- Extension icon from [labelary.com](http://labelary.com/)
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![Labelary and PDF viewer](https://raw.githubusercontent.com/roelkneepkens/labelary-extension/main/img/labelary-use-gif.gif)
 
-View Labelary, PDF and other base64-encoded formats in separate panel on right-mouse-button click.
+View Labelary (ZPL), PDF and other base64-encoded formats in separate panel on right-mouse-button click.
 
 Use as follows:
 - Right-click somewhere in the Labelary or Base64 string in the Editor

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ View Labelary, PDF and other base64-encoded formats in separate panel on right-m
 
 Use as follows:
 - Right-click somewhere in the Labelary or Base64 string in the Editor
-- Select `View Panel`
+- Select `View label`
 
-Alternatively, use `Ctrl` + `Shift` + `P` and search for `View Panel`.
+Alternatively, use `Ctrl` + `Shift` + `P` and search for `View label`.
 
 ## Supports
 - Labelary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "labelary",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "labelary",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Labelary and PDF viewer",
   "description": "View Labelary, PDF and other base64-encoded formats in separate panel on right-mouse-button click.",
   "license": "MIT",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publisher": "RoelKneepkens-ShipitSmarter",
   "author": {
 		"name": "Roel Kneepkens",

--- a/package.json
+++ b/package.json
@@ -34,20 +34,30 @@
     "Viewer"
   ],
   "activationEvents": [
-    "onCommand:labelary.view-label"
+    "onCommand:labelary.view-zpl-label",
+    "onCommand:labelary.view-base64-label"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "labelary.view-label",
-        "title": "View label"
+        "command": "labelary.view-zpl-label",
+        "title": "View raw ZPL label"
+      },
+      {
+        "command": "labelary.view-base64-label",
+        "title": "View Base64 label"
       }
     ],
     "menus": {
       "editor/context": [
         {
-          "command": "labelary.view-label",
+          "command": "labelary.view-zpl-label",
+          "when": "editorTextFocus || editorHasSelection || editorReadonly || isInDiffEditor || isInEmbeddedEditor",
+          "group": "labelary"
+        },
+        {
+          "command": "labelary.view-base64-label",
           "when": "editorTextFocus || editorHasSelection || editorReadonly || isInDiffEditor || isInEmbeddedEditor",
           "group": "labelary"
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "labelary",
   "displayName": "Labelary and PDF viewer",
-  "description": "View Labelary, PDF and other base64-encoded formats in separate panel on right-mouse-button click.",
+  "description": "View Labelary (ZPL), PDF and other base64-encoded formats in separate panel on right-mouse-button click.",
   "license": "MIT",
   "version": "1.0.5",
   "publisher": "RoelKneepkens-ShipitSmarter",
@@ -28,6 +28,7 @@
   "keywords": [
     "ShipitSmarter",
     "Labelary",
+    "ZPL",
     "PDF",
     "Base64",
     "Viewer"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,10 +3,17 @@ import { LabelaryPanel } from './panels/labelary_panel';
 
 
 export function activate(context: vscode.ExtensionContext) {
-	// Create Integration panel
-	const labelaryPanelCommand = vscode.commands.registerCommand('labelary.view-label', () => {
-		LabelaryPanel.render(context.extensionUri, context);
+	// Command for raw ZPL label
+	const rawZplPanelCommand = vscode.commands.registerCommand('labelary.view-zpl-label', () => {
+		LabelaryPanel.render(context.extensionUri, context, 'zpl');
 	});
 	
-	context.subscriptions.push(labelaryPanelCommand);	
+	context.subscriptions.push(rawZplPanelCommand);
+
+	// Command for raw ZPL label
+	const Base64PanelCommand = vscode.commands.registerCommand('labelary.view-base64-label', () => {
+		LabelaryPanel.render(context.extensionUri, context, 'base64');
+	});
+	
+	context.subscriptions.push(Base64PanelCommand);	
 }

--- a/src/panels/labelary_panel.ts
+++ b/src/panels/labelary_panel.ts
@@ -13,9 +13,12 @@ export class LabelaryPanel {
   //private _panel: vscode.WebviewPanel;
   private _labelString: string = '';
   private _disposables: vscode.Disposable[] = [];
+  private _type: string = 'base64';
 
   // constructor
-  private constructor(extensionUri: vscode.Uri, context: vscode.ExtensionContext) {
+  private constructor(extensionUri: vscode.Uri, context: vscode.ExtensionContext, type:string) {
+    // set type
+    this._type = type;
 
     // retrieve intended label string
     this._labelString = this._getIntendedLabelString();
@@ -32,8 +35,8 @@ export class LabelaryPanel {
   }
 
   // METHODS
-  public static render(extensionUri: vscode.Uri, context: vscode.ExtensionContext) {
-      LabelaryPanel.currentPanel = new LabelaryPanel(extensionUri, context);
+  public static render(extensionUri: vscode.Uri, context: vscode.ExtensionContext, type:string) {
+      LabelaryPanel.currentPanel = new LabelaryPanel(extensionUri, context, type);
   }
 
   // private _updateWebview(extensionUri: vscode.Uri) {
@@ -63,10 +66,10 @@ export class LabelaryPanel {
         let lastLineLastCharacter:  number = document.lineAt(lastLine).text.length;
   
         let textBeforeRaw = document.getText(new vscode.Range(new vscode.Position(0,0), new vscode.Position(cursorLineNumber, cursorCharNumber)));
-        let labelStringBefore = reverseString(removeAfterFirstDelimiter(reverseString(removeNewlines(textBeforeRaw))));
+        let labelStringBefore = reverseString(removeAfterFirstDelimiter(reverseString(removeNewlines(textBeforeRaw)),this._type));
 
         let textAfterRaw =  document.getText(new vscode.Range(new vscode.Position(cursorLineNumber,cursorCharNumber), new vscode.Position(lastLine, lastLineLastCharacter)));
-        let labelStringAfter = removeAfterFirstDelimiter(removeNewlines(textAfterRaw));
+        let labelStringAfter = removeAfterFirstDelimiter(removeNewlines(textAfterRaw),this._type);
 
         intendedLabelString = labelStringBefore + labelStringAfter;
       }

--- a/src/panels/labelary_panel.ts
+++ b/src/panels/labelary_panel.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import axios from 'axios';
-import { getUri, removeAfterFirstQuote, removeNewlines, reverseString } from "../utilities/functions";
+import { getUri, removeAfterFirstDelimiter, removeNewlines, reverseString } from "../utilities/functions";
 import { Base64Utils } from '../utilities/base64utils';
 import { Localizer } from '../utilities/localizer';
 import { View } from '../utilities/view';
@@ -63,10 +63,10 @@ export class LabelaryPanel {
         let lastLineLastCharacter:  number = document.lineAt(lastLine).text.length;
   
         let textBeforeRaw = document.getText(new vscode.Range(new vscode.Position(0,0), new vscode.Position(cursorLineNumber, cursorCharNumber)));
-        let labelStringBefore = reverseString(removeAfterFirstQuote(reverseString(removeNewlines(textBeforeRaw))));
+        let labelStringBefore = reverseString(removeAfterFirstDelimiter(reverseString(removeNewlines(textBeforeRaw))));
 
         let textAfterRaw =  document.getText(new vscode.Range(new vscode.Position(cursorLineNumber,cursorCharNumber), new vscode.Position(lastLine, lastLineLastCharacter)));
-        let labelStringAfter = removeAfterFirstQuote(removeNewlines(textAfterRaw));
+        let labelStringAfter = removeAfterFirstDelimiter(removeNewlines(textAfterRaw));
 
         intendedLabelString = labelStringBefore + labelStringAfter;
       }

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -13,5 +13,5 @@ export function reverseString(string: string) : string {
 }
 
 export function removeAfterFirstQuote(string: string) : string {
-	return string.replace(/["'`<>\s\|\[\]\{\}\(\)\\\/][\s\S]*$/g,'');
+	return string.replace(/["<>][\s\S]*$/g,'');
 }

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -12,6 +12,6 @@ export function reverseString(string: string) : string {
 	return string.split("").reverse().join("");
 }
 
-export function removeAfterFirstQuote(string: string) : string {
+export function removeAfterFirstDelimiter(string: string) : string {
 	return string.replace(/["<>][\s\S]*$/g,'');
 }

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -13,5 +13,5 @@ export function reverseString(string: string) : string {
 }
 
 export function removeAfterFirstQuote(string: string) : string {
-	return string.replace(/["'`][\s\S]*$/g,'');
+	return string.replace(/["'`<>\s\|,\[\]\{\}\(\)\\\/][\s\S]*$/g,'');
 }

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -12,6 +12,8 @@ export function reverseString(string: string) : string {
 	return string.split("").reverse().join("");
 }
 
-export function removeAfterFirstDelimiter(string: string) : string {
-	return string.replace(/["<>][\s\S]*$/g,'');
+export function removeAfterFirstDelimiter(string: string, type: string) : string {
+	let outString = (type === 'zpl') ? string.replace(/["<>][\s\S]*$/g,'') : string.replace(/["'`<>\{\}\[\]\(\)\|\\\/:;,\s][\s\S]*$/g,'');
+
+	return outString;
 }

--- a/src/utilities/functions.ts
+++ b/src/utilities/functions.ts
@@ -13,5 +13,5 @@ export function reverseString(string: string) : string {
 }
 
 export function removeAfterFirstQuote(string: string) : string {
-	return string.replace(/["'`<>\s\|,\[\]\{\}\(\)\\\/][\s\S]*$/g,'');
+	return string.replace(/["'`<>\s\|\[\]\{\}\(\)\\\/][\s\S]*$/g,'');
 }


### PR DESCRIPTION
String delimiters are now: "'`<>|{}[]()/\ and whitespaces, newlines, carriage returns